### PR TITLE
feat: increase connection timeout for chat socket

### DIFF
--- a/DataAccess/Sockets/ChatSocket.cs
+++ b/DataAccess/Sockets/ChatSocket.cs
@@ -30,7 +30,9 @@ public class ChatSocket
             new SocketIOOptions
             {
                 // Need to initialize the ExtraHeaders dictionary, as the library doesn't do so
-                ExtraHeaders = new Dictionary<string, string>()
+                ExtraHeaders = new Dictionary<string, string>(),
+                // Increase the connection timeout as render can sometimes take a while to connect
+                ConnectionTimeout = TimeSpan.FromSeconds(60),
             });
     }
 


### PR DESCRIPTION
render takes some time to spin up and sometimes its more than the default of 20 seconds so the bot just fails to connect and dies.